### PR TITLE
Add value bins route

### DIFF
--- a/frontend/app/features/values/components/bins.tsx
+++ b/frontend/app/features/values/components/bins.tsx
@@ -59,6 +59,7 @@ export function ValueBins() {
   const cardRef = useRef<HTMLDivElement>(null);
   const [index, setIndex] = useState(0);
   const [bins, setBins] = useState<string[][]>([[], [], [], []]);
+  const [animating, setAnimating] = useState(false);
   const value = VALUES[index];
 
   useEffect(() => {
@@ -70,7 +71,7 @@ export function ValueBins() {
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [index]);
+  }, [index, animating]);
 
   useEffect(() => {
     const el = cardRef.current;
@@ -80,10 +81,15 @@ export function ValueBins() {
         el.style.transition = "opacity 300ms";
         el.style.opacity = "1";
       });
+      // allow next interaction after fade-in completes
+      const timer = setTimeout(() => setAnimating(false), 300);
+      return () => clearTimeout(timer);
     }
   }, [index]);
 
   function handleSelect(binIndex: number) {
+    if (animating) return;
+    setAnimating(true);
     const el = cardRef.current;
     const bin = binRefs.current[binIndex];
     if (!el || !bin || !value) return;

--- a/frontend/app/features/values/components/bins.tsx
+++ b/frontend/app/features/values/components/bins.tsx
@@ -119,39 +119,43 @@ export function ValueBins() {
 
   if (!value) {
     return (
-      <div className="p-4 space-y-8">
+      <div className="min-h-screen flex flex-col bg-slate-100 p-4">
         <div className="h-2 w-full bg-gray-200 rounded">
           <div
             className="h-full bg-blue-500 rounded transition-all"
             style={{ width: `${progress}%` }}
           />
         </div>
-        <div className="text-center py-10">All done!</div>
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center py-10">All done!</div>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="p-4 space-y-8">
-      <div className="h-2 w-full bg-gray-200 rounded">
-        <div
-          className="h-full bg-blue-500 rounded transition-all"
-          style={{ width: `${progress}%` }}
-        />
+    <div className="min-h-screen flex flex-col bg-slate-100">
+      <div className="p-4">
+        <div className="h-2 w-full bg-gray-200 rounded">
+          <div
+            className="h-full bg-blue-500 rounded transition-all"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
       </div>
-      <div className="relative h-40 flex items-center justify-center">
+      <div className="flex-1 flex items-center justify-center">
         <div
           ref={cardRef}
           draggable
           onDragStart={(e) => e.dataTransfer.setData("text/plain", value)}
           className={cn(
-            "p-4 bg-white rounded shadow transition-transform duration-300"
+            "p-6 bg-slate-50 rounded-xl shadow-lg text-2xl font-semibold transition-transform duration-300"
           )}
         >
           {value}
         </div>
       </div>
-      <div className="grid grid-cols-4 gap-4">
+      <div className="p-4 grid grid-cols-4 gap-4">
         {[0, 1, 2, 3].map((i) => (
           <div key={i} className="flex flex-col items-center">
             <div className="font-bold mb-2">{i + 1}</div>
@@ -161,7 +165,7 @@ export function ValueBins() {
               }}
               onDragOver={(e) => e.preventDefault()}
               onDrop={() => handleDrop(i)}
-              className="h-24 w-full border-2 border-dashed rounded flex items-center justify-center"
+              className="h-32 w-full border-2 border-dashed border-slate-400 rounded flex items-center justify-center bg-slate-200/50"
             >
               {bins[i].length}
             </div>

--- a/frontend/app/features/values/components/bins.tsx
+++ b/frontend/app/features/values/components/bins.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from "react";
+import { cn } from "~/lib/utils";
+
+const VALUES = [
+  "Achievement",
+  "Adventure",
+  "Authenticity",
+  "Balance",
+  "Compassion",
+  "Contribution",
+  "Creativity",
+  "Curiosity",
+  "Empathy",
+  "Faith",
+  "Family",
+  "Freedom",
+  "Friendship",
+  "Growth",
+  "Health",
+  "Honesty",
+  "Humor",
+  "Independence",
+  "Innovation",
+  "Integrity",
+  "Justice",
+  "Leadership",
+  "Learning",
+  "Love",
+  "Loyalty",
+  "Open-mindedness",
+  "Optimism",
+  "Passion",
+  "Patience",
+  "Peace",
+  "Perseverance",
+  "Positivity",
+  "Quality",
+  "Reliability",
+  "Respect",
+  "Responsibility",
+  "Security",
+  "Service",
+  "Simplicity",
+  "Spirituality",
+  "Success",
+  "Sustainability",
+  "Teamwork",
+  "Tradition",
+  "Trustworthiness",
+  "Wealth",
+  "Wellness",
+  "Wisdom",
+  "Vision",
+  "Joy"
+];
+
+export function ValueBins() {
+  const binRefs = useRef<HTMLDivElement[]>([]);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [index, setIndex] = useState(0);
+  const [bins, setBins] = useState<string[][]>([[], [], [], []]);
+  const value = VALUES[index];
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const n = parseInt(e.key);
+      if (n >= 1 && n <= 4) {
+        handleSelect(n - 1);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [index]);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (el) {
+      el.style.opacity = "0";
+      requestAnimationFrame(() => {
+        el.style.transition = "opacity 300ms";
+        el.style.opacity = "1";
+      });
+    }
+  }, [index]);
+
+  function handleSelect(binIndex: number) {
+    const el = cardRef.current;
+    const bin = binRefs.current[binIndex];
+    if (!el || !bin || !value) return;
+    const cardRect = el.getBoundingClientRect();
+    const binRect = bin.getBoundingClientRect();
+    const dx =
+      binRect.left + binRect.width / 2 - (cardRect.left + cardRect.width / 2);
+    const dy =
+      binRect.top + binRect.height / 2 - (cardRect.top + cardRect.height / 2);
+    el.style.transition = "transform 300ms, opacity 300ms";
+    el.style.transform = `translate(${dx}px, ${dy}px)`;
+    el.style.opacity = "0";
+    setTimeout(() => {
+      setBins((prev) => {
+        const copy = prev.map((arr) => [...arr]);
+        copy[binIndex].push(value);
+        return copy;
+      });
+      if (el) {
+        el.style.transition = "none";
+        el.style.transform = "translate(0,0)";
+      }
+      setIndex((i) => i + 1);
+    }, 300);
+  }
+
+  function handleDrop(i: number) {
+    handleSelect(i);
+  }
+
+  if (!value) {
+    return <div className="text-center py-10">All done!</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-8">
+      <div className="grid grid-cols-4 gap-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="flex flex-col items-center">
+            <div className="font-bold mb-2">{i + 1}</div>
+            <div
+              ref={(el) => {
+                if (el) binRefs.current[i] = el;
+              }}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => handleDrop(i)}
+              className="h-24 w-full border-2 border-dashed rounded flex items-center justify-center"
+            >
+              {bins[i].length}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="relative h-40">
+        <div
+          ref={cardRef}
+          draggable
+          onDragStart={(e) => e.dataTransfer.setData("text/plain", value)}
+          className={cn(
+            "absolute left-1/2 -translate-x-1/2 p-4 bg-white rounded shadow transition-transform duration-300"
+          )}
+        >
+          {value}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/features/values/components/bins.tsx
+++ b/frontend/app/features/values/components/bins.tsx
@@ -102,6 +102,7 @@ export function ValueBins() {
         copy[binIndex].push(value);
         return copy;
       });
+      console.log(`${value}: ${binIndex + 1}`);
       if (el) {
         el.style.transition = "none";
         el.style.transform = "translate(0,0)";
@@ -114,12 +115,42 @@ export function ValueBins() {
     handleSelect(i);
   }
 
+  const progress = (index / VALUES.length) * 100;
+
   if (!value) {
-    return <div className="text-center py-10">All done!</div>;
+    return (
+      <div className="p-4 space-y-8">
+        <div className="h-2 w-full bg-gray-200 rounded">
+          <div
+            className="h-full bg-blue-500 rounded transition-all"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <div className="text-center py-10">All done!</div>
+      </div>
+    );
   }
 
   return (
     <div className="p-4 space-y-8">
+      <div className="h-2 w-full bg-gray-200 rounded">
+        <div
+          className="h-full bg-blue-500 rounded transition-all"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <div className="relative h-40 flex items-center justify-center">
+        <div
+          ref={cardRef}
+          draggable
+          onDragStart={(e) => e.dataTransfer.setData("text/plain", value)}
+          className={cn(
+            "p-4 bg-white rounded shadow transition-transform duration-300"
+          )}
+        >
+          {value}
+        </div>
+      </div>
       <div className="grid grid-cols-4 gap-4">
         {[0, 1, 2, 3].map((i) => (
           <div key={i} className="flex flex-col items-center">
@@ -136,18 +167,6 @@ export function ValueBins() {
             </div>
           </div>
         ))}
-      </div>
-      <div className="relative h-40">
-        <div
-          ref={cardRef}
-          draggable
-          onDragStart={(e) => e.dataTransfer.setData("text/plain", value)}
-          className={cn(
-            "absolute left-1/2 -translate-x-1/2 p-4 bg-white rounded shadow transition-transform duration-300"
-          )}
-        >
-          {value}
-        </div>
       </div>
     </div>
   );

--- a/frontend/app/features/values/pages/bins.tsx
+++ b/frontend/app/features/values/pages/bins.tsx
@@ -1,0 +1,3 @@
+import { ValueBins } from "../components/bins";
+
+export default ValueBins;

--- a/frontend/app/features/values/routes.ts
+++ b/frontend/app/features/values/routes.ts
@@ -1,7 +1,8 @@
-import { prefix, index } from "@react-router/dev/routes";
+import { prefix, index, route } from "@react-router/dev/routes";
 
 export const valuesRoutes =
-	prefix("values", [
-		index("features/values/pages/prompts.tsx"),
-	])
+        prefix("values", [
+                index("features/values/pages/prompts.tsx"),
+                route("bins", "features/values/pages/bins.tsx"),
+        ])
 

--- a/frontend/app/lib/useDebounce.ts
+++ b/frontend/app/lib/useDebounce.ts
@@ -21,7 +21,13 @@ export function useDebounce<T extends (...args: any[]) => void>(
   );
 
   /* clear timer on unmount */
-  useEffect(() => () => timer.current && clearTimeout(timer.current), []);
+  useEffect(() => {
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, []);
 
   return debounced;
 }


### PR DESCRIPTION
## Summary
- create ValueBins component for drag n' drop sort with keyboard support
- wire `/values/bins` route to new component
- fix `useDebounce` cleanup logic

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6840d8d474f4832ea37a1c043edf757d