### PR TITLE
Add docker compose files for dev/prod

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  backend:
+    image: php:8.1-cli
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: php -S 0.0.0.0:8000 -t public
+    ports:
+      - "8000:8000"
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    command: sh -c "npm install && npm run dev"
+    ports:
+      - "5173:5173"
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  backend:
+    image: php:8.1-cli
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: php -S 0.0.0.0:8000 -t public
+    expose:
+      - "8000"
+
+  frontend-build:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    command: sh -c "npm install && npm run build"
+
+  nginx:
+    image: nginx:alpine
+    depends_on:
+      - backend
+      - frontend-build
+    volumes:
+      - ./frontend/build/client:/usr/share/nginx/html:ro
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:80"
+

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add docker-compose.dev.yml for local PHP and React dev servers
- add docker-compose.prod.yml to build frontend, run PHP, and serve through nginx
- add nginx config for proxying to backend and serving built React

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684388953ff4832eb77894877487c3a8