### PR TITLE
Implement dynamic refine page

### DIFF
--- a/frontend/app/components/rich/MarkdownEditorField.tsx
+++ b/frontend/app/components/rich/MarkdownEditorField.tsx
@@ -93,7 +93,7 @@ export const MarkdownEditorField = ({
             <div className="rounded border border-slate-200">
               <MDXEditor
                 ref={editorRef}
-                markdown=""
+                markdown={field.value}
                 onChange={debouncedSave}
                 onBlur={() => {
                   field.onBlur();

--- a/frontend/app/features/values/pages/refine.tsx
+++ b/frontend/app/features/values/pages/refine.tsx
@@ -1,59 +1,107 @@
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 
 import { MarkdownEditorField } from "~/components/rich/MarkdownEditorField"
 
 import { Button } from "~/components/ui/button"
+import { Input } from "~/components/ui/input"
 import {
-	Form,
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
 } from "~/components/ui/form"
 
 const ValueRefinementQuestions = z.object({
-	q1: z.string().min(1, "Required"),
+  name: z.string().min(1, "Required"),
+  q1: z.string().min(1, "Required"),
 })
 
 type ValueRefineAnswers = z.infer<typeof ValueRefinementQuestions>
 
-function ValueRefinePrompts() {
-	const form = useForm<ValueRefineAnswers>({
-		resolver: zodResolver(ValueRefinementQuestions),
-		defaultValues: {
-			q1: "**Define this value in your own words.**\n\n\n**What are some examples of this value from your life?**\n\n\n**What are the costs of ignoring this value?**\n\n\n**What are some behaviors that would exhibit this value?**\n\n\n",
-		},
-	})
-
-	function onSubmit(answers: ValueRefineAnswers) {
-		console.log(answers)
-	}
-
-	return (
-		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8 max-w-7xl">
-				<input type="text" placeholder="Name of Value" />
-				<MarkdownEditorField
-					name="q1"
-					control={form.control}
-					label="Write about this value"
-				/>
-				<Button type="submit">Submit</Button>
-			</form>
-		</Form >
-	)
+interface ValueRefinePromptsProps {
+  onSubmit: (answers: ValueRefineAnswers) => void
 }
 
+function ValueRefinePrompts({ onSubmit }: ValueRefinePromptsProps) {
+  const form = useForm<ValueRefineAnswers>({
+    resolver: zodResolver(ValueRefinementQuestions),
+    defaultValues: {
+      name: "",
+      q1: "**Define this value in your own words.**\n\n\n**What are some examples of this value from your life?**\n\n\n**What are the costs of ignoring this value?**\n\n\n**What are some behaviors that would exhibit this value?**\n\n\n",
+    },
+  })
+
+  function handleSubmit(answers: ValueRefineAnswers) {
+    onSubmit(answers)
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className="space-y-8 max-w-7xl"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name of Value</FormLabel>
+              <FormControl>
+                <Input placeholder="Name of Value" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <MarkdownEditorField
+          name="q1"
+          control={form.control}
+          label="Write about this value"
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  )
+}
+
+import { VALUES_LIST } from "../data"
+
 export default function RefineCluster() {
-	return (
-		<div className="flex flex-col items-center justify-center h-full">
-			<h1 className="text-2xl font-bold mb-4">Cluster X</h1>
-			<ul>
-				<li>Value 1</li>
-				<li>Value 2</li>
-				<li>Value 3</li>
-				<li>Value 4</li>
-				<li>Value 5</li>
-			</ul>
-			<ValueRefinePrompts />
-		</div>
-	)
+  const clusters = [
+    { name: "Cluster 1", values: VALUES_LIST.slice(0, 5) },
+    { name: "Cluster 2", values: VALUES_LIST.slice(5, 10) },
+    { name: "Cluster 3", values: VALUES_LIST.slice(10, 15) },
+  ]
+
+  const [index, setIndex] = useState(0)
+  const [answers, setAnswers] = useState<ValueRefineAnswers[]>([])
+
+  function handleNext(a: ValueRefineAnswers) {
+    setAnswers((prev) => [...prev, a])
+    if (index < clusters.length - 1) {
+      setIndex((i) => i + 1)
+    } else {
+      console.log("All done", [...answers, a])
+    }
+  }
+
+  const cluster = clusters[index]
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full">
+      <h1 className="text-2xl font-bold mb-4">{cluster.name}</h1>
+      <ul>
+        {cluster.values.map((v) => (
+          <li key={v}>{v}</li>
+        ))}
+      </ul>
+      <ValueRefinePrompts key={index} onSubmit={handleNext} />
+    </div>
+  )
 }

--- a/frontend/app/features/values/pages/refine.tsx
+++ b/frontend/app/features/values/pages/refine.tsx
@@ -32,7 +32,19 @@ function ValueRefinePrompts({ onSubmit }: ValueRefinePromptsProps) {
     resolver: zodResolver(ValueRefinementQuestions),
     defaultValues: {
       name: "",
-      q1: "**Define this value in your own words.**\n\n\n**What are some examples of this value from your life?**\n\n\n**What are the costs of ignoring this value?**\n\n\n**What are some behaviors that would exhibit this value?**\n\n\n",
+      q1: `**Define this value in your own words.**<br /><br />\n\n
+**What are some examples of this value from your life?**<br /><br />
+
+
+
+**What are the costs of ignoring this value?**
+
+
+
+**What are some behaviors that would exhibit this value?**
+
+
+`,
     },
   })
 


### PR DESCRIPTION
## Summary
- persist Markdown text by pulling from form state
- include value name field in refine form
- add ability to cycle through clusters on the refine page

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_688924ea1dfc832e8c80bb8c2f450d3f