### PR TITLE
Implement dynamic refine page

### DIFF
--- a/frontend/app/components/rich/MarkdownEditorField.tsx
+++ b/frontend/app/components/rich/MarkdownEditorField.tsx
@@ -93,7 +93,7 @@ export const MarkdownEditorField = ({
             <div className="rounded border border-slate-200">
               <MDXEditor
                 ref={editorRef}
-                markdown=""
+                markdown={field.value}
                 onChange={debouncedSave}
                 onBlur={() => {
                   field.onBlur();


### PR DESCRIPTION
## Summary
- persist Markdown text by pulling from form state
- include value name field in refine form
- add ability to cycle through clusters on the refine page
- generate clusters dynamically and keep answers per cluster

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_688924ea1dfc832e8c80bb8c2f450d3f